### PR TITLE
fix: do not rely on Icon from antd anymore

### DIFF
--- a/src/ShapeTool.tsx
+++ b/src/ShapeTool.tsx
@@ -1,6 +1,6 @@
 import Tool, { ToolOption, ShapeType, strokeSize, strokeColor } from './enums/Tool';
 import React, { useContext } from 'react';
-import { Icon } from 'antd';
+import Icon from './icons/Icon';
 import './ShapeTool.less';
 
 export interface Position {
@@ -300,7 +300,7 @@ export const useShapeDropdown = (
               >
                 <div className={`${prefixCls}-fill`} style={{ background: color }}></div>
                 {currentToolOption.shapeBorderColor === color ? (
-                  <Icon type="check" style={color === '#ffffff' ? { color: '#979797' } : {}} />
+                  <Icon type="check" style={color === '#ffffff' ? { color: '#979797' } : {color: '#fff'}} />
                 ) : null}
               </div>
             );

--- a/src/SketchPad.tsx
+++ b/src/SketchPad.tsx
@@ -45,7 +45,7 @@ import {
 } from './SelectTool';
 import { defaultToolOption } from './enums/Tool';
 import { debounce } from 'lodash';
-import { Icon, Upload } from 'antd';
+import Icon from './icons/Icon';
 import { v4 } from 'uuid';
 import sketchStrokeCursor from './images/sketch_stroke_cursor';
 import { useZoomGesture } from './gesture';
@@ -1159,7 +1159,7 @@ const SketchPad: React.ForwardRefRenderFunction<any, SketchPadProps> = (props, r
 
     removeButton = (
       <div style={removeStyle} onMouseDown={onRemoveOperation} onTouchStart={onRemoveOperation}>
-        <Icon type="close-circle" theme="filled" />
+        <Icon type="close-circle" />
       </div>
     );
   }

--- a/src/StrokeTool.tsx
+++ b/src/StrokeTool.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import Tool, { strokeSize, strokeColor, ToolOption } from './enums/Tool';
 import { isMobileDevice } from './utils';
-import { Icon } from 'antd';
+import Icon from './icons/Icon';
 import './StrokeTool.less';
 
 interface Point {
@@ -218,7 +218,7 @@ export const useStrokeDropdown = (
               >
                 <div className={`${prefixCls}-fill`} style={{ background: color }}></div>
                 {currentToolOption.strokeColor === color ? (
-                  <Icon type="check" style={color === '#ffffff' ? { color: '#979797' } : {}} />
+                  <Icon type="check" style={color === '#ffffff' ? { color: '#979797' } : {color: '#fff'}} />
                 ) : null}
               </div>
             );

--- a/src/TextTool.tsx
+++ b/src/TextTool.tsx
@@ -3,7 +3,7 @@ import Tool, { ToolOption, Position, TextSize, strokeColor } from './enums/Tool'
 import { IntlShape } from 'react-intl';
 import { RefObject, MouseEvent as ReactMouseEvent } from 'react';
 import { mapClientToCanvas, isMobileDevice } from './utils';
-import { Icon } from 'antd';
+import Icon from './icons/Icon';
 import './TextTool.less';
 
 let currentText = '';
@@ -188,7 +188,7 @@ export const useTextDropdown = (
               >
                 <div className={`${prefixCls}-fill`} style={{ background: color }}></div>
                 {currentToolOption.textColor === color ? (
-                  <Icon type="check" style={color === '#ffffff' ? { color: '#979797' } : {}} />
+                  <Icon type="check" style={color === '#ffffff' ? { color: '#979797' } : {color: '#fff'}} />
                 ) : null}
               </div>
             );

--- a/src/icons/Icon.tsx
+++ b/src/icons/Icon.tsx
@@ -1,0 +1,34 @@
+import React, { useMemo } from 'react';
+
+interface IIconProps {
+  type: 'check' | 'close-circle';
+  style?: React.CSSProperties
+}
+
+export default function Icon({ type, style }: IIconProps) {
+  const iconText = useMemo(() => (type === 'check' ? '✓' : 'x'), [type]);
+  const addtionStyle = useMemo(() => (type === 'close-circle' ? {
+    borderRadius: '50%',
+    backgroundColor: 'red',
+    color: '#fff',
+    alignItems: 'flex-end',
+  } : {}), [type]);
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        justifyContent: 'center',
+        alignItems: 'center',
+        width: 15,
+        height: 15,
+        position: 'absolute',
+        fontSize: 12,
+        ...addtionStyle,
+        ...style
+      }}
+    >
+      {iconText}
+    </div>
+  );
+}


### PR DESCRIPTION
Remove `import { Icon } from 'antd'` with a simple internal implementation. 

This should fix #14 