### PR TITLE
Adds prepare to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
   ],
   "scripts": {
     "dev": "umi dev",
-    "build": "father build"
+    "build": "father build",
+    "prepare": "npm run build"
   },
   "dependencies": {
     "@types/vfile-message": "^2.0.0",


### PR DESCRIPTION
I forked the repository and added it as a dependency of another project, but I would get the following error message: `Module not found: Error: Can't resolve 'react-drawing-board'`. I found that was happening because the "compiled" files on the lib directory, such as plain JS and CSS files, were absent. Only the src directory, which had TypeScript and Less files, was present.

I found out that the problem could be solved if the library defined a `prepare` script on `package.json` (see https://stackoverflow.com/a/57829251/12440938). After doing that, the fork could be successfully used.

This PR fixes #21.