### PR TITLE
Make react &-dom dev and peer dependendies equal

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,15 +27,15 @@
     "uuid": "^3.3.3"
   },
   "peerDependencies": {
-    "react": ">=16.0.0",
-    "react-dom": ">=16.0.0"
+    "react": ">=16.5.2",
+    "react-dom": ">=16.5.2"
   },
   "devDependencies": {
     "@types/classnames": "^2.2.9",
     "@types/uuid": "^3.4.6",
     "father": "^2.29.1",
-    "react": "^16.5.2",
-    "react-dom": "^16.5.2",
+    "react": ">=16.5.2",
+    "react-dom": ">=16.5.2",
     "umi": "^2.9.0",
     "umi-plugin-block-dev": "^2.0.0",
     "umi-plugin-react": "^1.14.8",


### PR DESCRIPTION
The library works just fine on react version `17.0.1` with the equivalent react-dom version (tested locally).

Since the development dependency is at least `16.5.2`, I think the peer dependency should be as well, to make sure we are developing the library using the same react version being used in _production_ apps.

This should also avoid conflicts between react versions for apps using any version of react greater than or equal to `17.0.0` in development environments that would cause `Invalid Hook Call` errors.