### PR TITLE
Adds pt-BR translation

### DIFF
--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -1,8 +1,9 @@
 import enUS from './en-US';
 import zhCN from './zh-CN';
 import trTR from './tr-TR';
+import ptBR from './pt-BR';
 
-export type localeType = 'en-US' | 'zh-CN' | 'tr-TR' | 'en' | 'zh' | 'tr';
+export type localeType = 'en-US' | 'zh-CN' | 'tr-TR' | 'en' | 'zh' | 'tr' | 'pt-BR';
 
 export default {
   messages: {
@@ -12,5 +13,6 @@ export default {
     ['en']: enUS,
     ['zh']: zhCN,
     ['tr']: enUS,
+    ['pt-BR']: ptBR,
   },
 };

--- a/src/locales/pt-BR.ts
+++ b/src/locales/pt-BR.ts
@@ -1,0 +1,25 @@
+export default {
+  'umi.block.sketch.select': 'Selecionar',
+  'umi.block.sketch.pencil': 'Lápis (P)',
+  'umi.block.sketch.shape': 'Formas (R)',
+  'umi.block.sketch.text': 'Texto (T)',
+  'umi.block.sketch.image': 'Imagem',
+  'umi.block.sketch.background': 'Fundo',
+  'umi.block.sketch.undo': 'Desfazer',
+  'umi.block.sketch.redo': 'Refazer',
+  'umi.block.sketch.clear': 'Limpar',
+  'umi.block.sketch.eraser': 'Borracha',
+  'umi.block.sketch.save': 'Salvar',
+
+  'umi.block.sketch.text.placeholder': 'Escreva o texto aqui',
+  'umi.block.sketch.text.size.small': 'Pequeno',
+  'umi.block.sketch.text.size.default': 'Médio',
+  'umi.block.sketch.text.size.large': 'Grande',
+
+  'umi.block.sketch.bg.select': 'Selecionar',
+  'umi.block.sketch.bg.layout': 'Layout',
+  'umi.block.sketch.bg.fill': 'Esticar',
+  'umi.block.sketch.bg.contain': 'Aumentar proporcionalmente',
+  'umi.block.sketch.bg.not-resize': 'Preservar dimensões',
+  'umi.block.sketch.bg.remove': 'Remover',
+};


### PR DESCRIPTION
This commit adds support for a Brazilian Portuguese locale, by creating a locale file on src/locales.  I included translations for the background labels from https://github.com/dilidili/react-drawing-board/pull/25 so they are ready when needed, but they can be removed if necessary.